### PR TITLE
Fix memory leak: QCoreApplication::postEvent with DeactivateEvent never is executed.

### DIFF
--- a/elements/gstqtvideosink/delegates/basedelegate.cpp
+++ b/elements/gstqtvideosink/delegates/basedelegate.cpp
@@ -56,7 +56,8 @@ void BaseDelegate::setActive(bool active)
     QWriteLocker l(&m_isActiveLock);
     m_isActive = active;
     if (!active) {
-        QCoreApplication::postEvent(this, new DeactivateEvent());
+        DeactivateEvent event;
+        QCoreApplication::sendEvent(this,(QEvent*)&event);
     }
 }
 


### PR DESCRIPTION
Hi,
 
I found a problem during restart the video in qt quick application using QtGstreamer.
In my pc this problem occur and so I don't have any critical problem, but on some i.MX6 board occurs memory leak in DMA allocation.
This problem occurs because 'DeactivateEvent' scheduled by 'postEvent' is never executed. Please see log attached: [qt-gstreamer-fail.txt](https://github.com/GStreamer/qt-gstreamer/files/468150/qt-gstreamer-fail.txt).
There you can see that after 'Deactivating' it never writes the log 'Received deactivate event',
simply this event is lost.
To fix this, I replaced method postEvent with sendEvent. Please see log 
attached: [qt-gstreamer-ok.txt](https://github.com/GStreamer/qt-gstreamer/files/468149/qt-gstreamer-ok.txt).
After this fix, the 'Received deactivate event' always occurs after 'Deactivating'.
 
I created an application to make a test:
https://github.com/Danfx/qtteste/tree/master/QuickTest

Please, comment.

Best Regards,
Daniel Fussia.