### PR TITLE
Remove BOOST_TT_HAS_OPERATOR_HPP_INCLUDED workaround

### DIFF
--- a/src/QGlib/connect.h
+++ b/src/QGlib/connect.h
@@ -25,8 +25,10 @@
 #include <QtCore/QSharedPointer>
 #include <QtCore/QFlags>
 #include <QtCore/QHash>
+#ifndef Q_MOC_RUN
 #include <boost/type_traits.hpp>
 #include <boost/utility/enable_if.hpp>
+#endif
 
 namespace QGlib {
 

--- a/src/QGlib/connectimpl.h
+++ b/src/QGlib/connectimpl.h
@@ -26,7 +26,9 @@
 # include "refpointer.h"
 # include <QtCore/QList>
 # include <stdexcept>
+#ifndef Q_MOC_RUN
 # include <boost/type_traits.hpp>
+#endif
 
 
 namespace QGlib {

--- a/src/QGlib/global.h
+++ b/src/QGlib/global.h
@@ -17,13 +17,11 @@
 #ifndef QGLIB_GLOBAL_H
 #define QGLIB_GLOBAL_H
 
-// workaround for https://bugreports.qt-project.org/browse/QTBUG-22829
-#if defined(Q_MOC_RUN) && !defined(BOOST_TT_HAS_OPERATOR_HPP_INCLUDED)
-#define BOOST_TT_HAS_OPERATOR_HPP_INCLUDED
-#endif
-
 #include <QtCore/QtGlobal>
+
+#ifndef Q_MOC_RUN
 #include <boost/config.hpp>
+#endif
 
 /* defined by cmake when building this library */
 #if defined(QtGLib_EXPORTS) || defined(Qt5GLib_EXPORTS)
@@ -84,8 +82,10 @@ typedef RefPointer<Object> ObjectPtr;
 # define QGLIB_STATIC_ASSERT(expr, message) static_assert(expr, message)
 # define QGLIB_HAVE_CXX0X_STATIC_ASSERT 1
 #else
+#ifndef Q_MOC_RUN
 # include <boost/static_assert.hpp>
 # define QGLIB_STATIC_ASSERT(expr, message) BOOST_STATIC_ASSERT(expr)
+#endif
 #endif
 
 //check for the C++0x features that we need

--- a/src/QGlib/refpointer.h
+++ b/src/QGlib/refpointer.h
@@ -23,8 +23,10 @@
 #include "type.h"
 #include "wrap.h"
 #include <cstddef>
+#ifndef Q_MOC_RUN
 #include <boost/type_traits.hpp>
 #include <boost/utility/enable_if.hpp>
+#endif
 #include <QtCore/QHash>
 
 namespace QGlib {

--- a/src/QGlib/type.h
+++ b/src/QGlib/type.h
@@ -21,8 +21,9 @@
 
 #include "global.h"
 #include <QtCore/QList>
+#ifndef Q_MOC_RUN
 #include <boost/mpl/if.hpp>
-
+#endif
 /*
  * This is a re-definition of GType inside the QGlib::Private namespace.
  * It is used in the headers to avoid including <glib-object.h>.

--- a/src/QGlib/value.h
+++ b/src/QGlib/value.h
@@ -23,8 +23,10 @@
 #include "type.h"
 #include "refpointer.h"
 #include "error.h"
+#ifndef Q_MOC_RUN
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits.hpp>
+#endif
 #include <stdexcept>
 #include <QtCore/QString>
 #include <QtCore/QDebug>

--- a/src/QGst/Quick/global.h
+++ b/src/QGst/Quick/global.h
@@ -18,11 +18,6 @@
 #ifndef QTGSTREAMERQUICK_EXPORT_H
 #define QTGSTREAMERQUICK_EXPORT_H
 
-// workaround for https://bugreports.qt-project.org/browse/QTBUG-22829
-#if defined(Q_MOC_RUN) && !defined(BOOST_TT_HAS_OPERATOR_HPP_INCLUDED)
-#define BOOST_TT_HAS_OPERATOR_HPP_INCLUDED
-#endif
-
 #include <QtCore/QtGlobal>
 
 /* defined by cmake when building this library */

--- a/src/QGst/Ui/global.h
+++ b/src/QGst/Ui/global.h
@@ -18,11 +18,6 @@
 #ifndef QTGSTREAMERUI_EXPORT_H
 #define QTGSTREAMERUI_EXPORT_H
 
-// workaround for https://bugreports.qt-project.org/browse/QTBUG-22829
-#if defined(Q_MOC_RUN) && !defined(BOOST_TT_HAS_OPERATOR_HPP_INCLUDED)
-#define BOOST_TT_HAS_OPERATOR_HPP_INCLUDED
-#endif
-
 #include <QtCore/QtGlobal>
 
 /* defined by cmake when building this library */

--- a/src/QGst/Utils/global.h
+++ b/src/QGst/Utils/global.h
@@ -18,11 +18,6 @@
 #ifndef QGST_UTILS_GLOBAL_H
 #define QGST_UTILS_GLOBAL_H
 
-// workaround for https://bugreports.qt-project.org/browse/QTBUG-22829
-#if defined(Q_MOC_RUN) && !defined(BOOST_TT_HAS_OPERATOR_HPP_INCLUDED)
-#define BOOST_TT_HAS_OPERATOR_HPP_INCLUDED
-#endif
-
 #include <QtCore/QtGlobal>
 
 /* defined by cmake when building this library */

--- a/src/QGst/element.h
+++ b/src/QGst/element.h
@@ -22,7 +22,9 @@
 #include "clocktime.h"
 
 #if !QGLIB_HAVE_CXX0X
+#ifndef Q_MOC_RUN
 # include <boost/preprocessor.hpp>
+#endif
 #endif
 
 namespace QGst {

--- a/src/QGst/global.h
+++ b/src/QGst/global.h
@@ -17,11 +17,6 @@
 #ifndef QGST_GLOBAL_H
 #define QGST_GLOBAL_H
 
-// workaround for https://bugreports.qt-project.org/browse/QTBUG-22829
-#if defined(Q_MOC_RUN) && !defined(BOOST_TT_HAS_OPERATOR_HPP_INCLUDED)
-#define BOOST_TT_HAS_OPERATOR_HPP_INCLUDED
-#endif
-
 #include "../QGlib/type.h"
 #include <QtCore/QtGlobal>
 #include <QtCore/QDate>


### PR DESCRIPTION
The old workaround to define BOOST_TT_HAS_OPERATOR_HPP_INCLUDED
doesn't work anymore with newer boost.

Commit 1d2edcc9562c8826fd17b5233691f4a313ab71c7 [1] fix only the
QGlib/QGst build but not the tests or any other consumer Qt/Moc build.

Tested with boost 1.57.0 and 1.64.0

[1]: https://github.com/GStreamer/qt-gstreamer/commit/1d2edcc9562c8826fd17b5233691f4a313ab71c7