### PR TITLE
Added wrapper for gst_buffer_memcmp

### DIFF
--- a/src/QGst/buffer.cpp
+++ b/src/QGst/buffer.cpp
@@ -83,6 +83,11 @@ uint Buffer::extract(uint offset, void *dest, uint size)
     return gst_buffer_extract(object<GstBuffer>(), offset, dest, size);
 }
 
+int Buffer::memoryCompare(uint offset, void *dest, uint size)
+{
+	return gst_buffer_memcmp(object<GstBuffer>(), offset, dest, size);
+}
+
 uint Buffer::memoryCount() const
 {
     return gst_buffer_n_memory (object<GstBuffer>());

--- a/src/QGst/buffer.h
+++ b/src/QGst/buffer.h
@@ -53,6 +53,7 @@ public:
     void setSize(uint size);
 
     uint extract(uint offset, void *dest, uint size);
+	int memoryCompare(uint offset, void *dest, uint size);
 
     uint memoryCount() const;
     MemoryPtr getMemory(uint index) const;


### PR DESCRIPTION
This is a much-needed function for comparing memory in a buffer. Without this, the only alternative is extracting the memory from the buffer and using C++ memcmp.